### PR TITLE
set paddle.cumsum output data type as 'int32' in CHGNet model.

### DIFF
--- a/ppmat/models/chgnet/chgnet.py
+++ b/ppmat/models/chgnet/chgnet.py
@@ -1449,7 +1449,7 @@ class CHGNet(paddle.nn.Layer):
         # Each element represents the index of two atoms
         atom_graph = graphs.edge_feat["atom_graph"]
         num_atom_graph = graphs.edge_feat["num_atom_graph"]
-        num_atoms_cumsum = paddle.cumsum(num_atoms)
+        num_atoms_cumsum = paddle.cumsum(num_atoms).astype('int32')
         num_atoms_cumsum = paddle.concat(
             [paddle.zeros(1, dtype=num_atoms_cumsum.dtype), num_atoms_cumsum]
         )
@@ -1485,7 +1485,7 @@ class CHGNet(paddle.nn.Layer):
 
         # Accumulate the number of edges in each crystal pattern and add it as an
         # offset to the index of each edge vector
-        num_edges_cumsum = paddle.cumsum(num_edges)
+        num_edges_cumsum = paddle.cumsum(num_edges).astype('int32')
         num_edges_cumsum = paddle.concat(
             [paddle.zeros(1, dtype=num_edges_cumsum.dtype), num_edges_cumsum]
         )
@@ -1515,7 +1515,7 @@ class CHGNet(paddle.nn.Layer):
 
         undirected2directed_len_cumsum = paddle.cumsum(
             graphs.edge_feat["undirected2directed_len"]
-        )
+        ).astype('int32')
         undirected2directed_len_cumsum = paddle.concat(
             [
                 paddle.zeros(1, dtype=undirected2directed_len_cumsum.dtype),


### PR DESCRIPTION
Ensure paddle.cumsum output dtype matches the input dtype (int32) in the CHGNet model.