### PR TITLE
【Hackathon 10th Spring No.15】DM2模型复现

### DIFF
--- a/ppmat/datasets/__init__.py
+++ b/ppmat/datasets/__init__.py
@@ -42,6 +42,7 @@ from ppmat.datasets.mptrj_dataset import MPTrjDataset
 from ppmat.datasets.msd_nmr_dataset import MSDnmrDataset
 from ppmat.datasets.msd_nmr_dataset import MSDnmrinfos
 from ppmat.datasets.density_dataset import DensityDataset
+from ppmat.datasets.dm2_dataset import DM2StructureDataset
 from ppmat.datasets.small_density_dataset import SmallDensityDataset 
 from ppmat.datasets.num_atom_crystal_dataset import NumAtomsCrystalDataset
 from ppmat.datasets.oc20_s2ef_dataset import OC20S2EFDataset  # noqa
@@ -65,6 +66,7 @@ __all__ = [
     "MSDnmrDataset",
     "MatbenchDataset",
     "DensityDataset", 
+    "DM2StructureDataset",
     "SmallDensityDataset",
     "OMol25Dataset",
 ]

--- a/ppmat/datasets/dm2_dataset.py
+++ b/ppmat/datasets/dm2_dataset.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import glob
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Union
+
+import ase.io
+import numpy as np
+import paddle
+from ase.neighborlist import primitive_neighbor_list
+from paddle.io import Dataset
+
+from ppmat.datasets.geometric_data_type.data import Data
+
+
+def _expand_paths(paths: Union[str, Sequence[str]]) -> List[str]:
+    if isinstance(paths, str):
+        paths = [paths]
+
+    expanded = []
+    for path in paths:
+        matches = sorted(glob.glob(path))
+        if matches:
+            expanded.extend(matches)
+        else:
+            expanded.append(path)
+    return expanded
+
+
+def _as_pbc_tuple(pbc) -> tuple[bool, bool, bool]:
+    arr = np.asarray(pbc, dtype=bool).reshape(-1)
+    if arr.size == 1:
+        arr = np.repeat(arr, 3)
+    return tuple(bool(x) for x in arr[:3])
+
+
+def ase_atoms_to_dm2_data(
+    atoms,
+    species_to_index: Dict[int, int],
+    cutoff: float,
+    cooling_rate: Optional[float] = None,
+) -> Data:
+    """Convert an ASE ``Atoms`` object to PaddleMaterials geometric ``Data``."""
+
+    atomic_numbers = np.asarray(atoms.numbers, dtype=np.int64)
+    x = np.asarray([species_to_index[int(z)] for z in atomic_numbers], dtype=np.int64)
+    pbc = _as_pbc_tuple(atoms.pbc)
+    cell = np.asarray(atoms.cell.array, dtype=np.float32)
+    positions = np.asarray(atoms.positions, dtype=np.float32)
+
+    src, dst, disp = primitive_neighbor_list(
+        "ijD",
+        cutoff=cutoff,
+        pbc=pbc,
+        cell=cell,
+        positions=positions,
+        numbers=atomic_numbers,
+    )
+    data = Data(
+        x=paddle.to_tensor(x, dtype="int64"),
+        pos=paddle.to_tensor(positions, dtype="float32"),
+        edge_index=paddle.to_tensor(np.stack([src, dst]), dtype="int64"),
+        edge_attr=paddle.to_tensor(disp, dtype="float32"),
+        atomic_numbers=paddle.to_tensor(atomic_numbers, dtype="int64"),
+        lattice=paddle.to_tensor(cell[None, :, :], dtype="float32"),
+        pbc=paddle.to_tensor(np.asarray(pbc, dtype=bool)[None, :], dtype="bool"),
+        num_nodes=len(atomic_numbers),
+    )
+    if cooling_rate is not None:
+        data.cooling_rate = paddle.to_tensor([cooling_rate], dtype="float32")
+    return data
+
+
+class DM2StructureDataset(Dataset):
+    """ASE-backed dataset for DM2 disordered-material denoising.
+
+    Args:
+        paths (str|Sequence[str]): Structure files or glob patterns. ASE is used for
+            reading, so formats such as ``lammps-data``, ``extxyz`` and ``cif`` are
+            supported through ``file_format``.
+        file_format (Optional[str]): ASE format string. Leave ``None`` to let ASE
+            infer the format.
+        cutoff (float): Large neighbor cutoff used before rattle/downselect.
+        species (Optional[Sequence[int]]): Ordered atomic numbers for species
+            encoding. If omitted, the dataset infers a sorted species list.
+        duplicate (int): Repeat each loaded structure this many times per epoch.
+        cooling_rates (Optional[Sequence[float]]): Per-structure conditioning values.
+            DM2 conditional training conventionally uses ``log10(cooling_rate)``;
+            set ``log10_cooling_rate=True`` to apply that transform here.
+        log10_cooling_rate (bool): Whether to store log10-transformed cooling rates.
+    """
+
+    def __init__(
+        self,
+        paths: Union[str, Sequence[str]],
+        file_format: Optional[str] = None,
+        cutoff: float = 10.0,
+        species: Optional[Sequence[int]] = None,
+        duplicate: int = 128,
+        cooling_rates: Optional[Sequence[float]] = None,
+        log10_cooling_rate: bool = True,
+    ):
+        super().__init__()
+        self.paths = _expand_paths(paths)
+        if len(self.paths) == 0:
+            raise ValueError("DM2StructureDataset received no structure files.")
+        self.file_format = file_format
+        self.cutoff = cutoff
+        self.duplicate = int(duplicate)
+        if self.duplicate <= 0:
+            raise ValueError("duplicate must be a positive integer.")
+
+        atoms_list = [
+            ase.io.read(path, format=file_format)
+            for path in self.paths
+        ]
+
+        if species is None:
+            unique_species = sorted(
+                {
+                    int(number)
+                    for atoms in atoms_list
+                    for number in np.asarray(atoms.numbers).tolist()
+                }
+            )
+        else:
+            unique_species = [int(number) for number in species]
+        self.species = unique_species
+        self.species_to_index = {z: idx for idx, z in enumerate(unique_species)}
+
+        if cooling_rates is not None and len(cooling_rates) != len(atoms_list):
+            raise ValueError(
+                "cooling_rates must be omitted or have the same length as paths."
+            )
+
+        self.graphs = []
+        for idx, atoms in enumerate(atoms_list):
+            cooling_rate = None
+            if cooling_rates is not None:
+                cooling_rate = float(cooling_rates[idx])
+                if log10_cooling_rate:
+                    cooling_rate = float(np.log10(cooling_rate))
+            self.graphs.append(
+                ase_atoms_to_dm2_data(
+                    atoms=atoms,
+                    species_to_index=self.species_to_index,
+                    cutoff=cutoff,
+                    cooling_rate=cooling_rate,
+                )
+            )
+
+    def __len__(self):
+        return len(self.graphs) * self.duplicate
+
+    def __getitem__(self, idx):
+        graph = self.graphs[idx % len(self.graphs)]
+        return graph.clone()

--- a/ppmat/datasets/dm2_dataset.py
+++ b/ppmat/datasets/dm2_dataset.py
@@ -101,7 +101,8 @@ class DM2StructureDataset(Dataset):
         species (Optional[Sequence[int]]): Ordered atomic numbers for species
             encoding. If omitted, the dataset infers a sorted species list.
         duplicate (int): Repeat each loaded structure this many times per epoch.
-        cooling_rates (Optional[Sequence[float]]): Per-structure conditioning values.
+        cooling_rates (Optional[float|Sequence[float]]): Per-structure conditioning
+            values. A scalar or one-item sequence is broadcast to all structures.
             DM2 conditional training conventionally uses ``log10(cooling_rate)``;
             set ``log10_cooling_rate=True`` to apply that transform here.
         log10_cooling_rate (bool): Whether to store log10-transformed cooling rates.
@@ -145,10 +146,16 @@ class DM2StructureDataset(Dataset):
         self.species = unique_species
         self.species_to_index = {z: idx for idx, z in enumerate(unique_species)}
 
-        if cooling_rates is not None and len(cooling_rates) != len(atoms_list):
-            raise ValueError(
-                "cooling_rates must be omitted or have the same length as paths."
-            )
+        if cooling_rates is not None:
+            if isinstance(cooling_rates, (int, float)):
+                cooling_rates = [float(cooling_rates)] * len(atoms_list)
+            elif len(cooling_rates) == 1 and len(atoms_list) > 1:
+                cooling_rates = [float(cooling_rates[0])] * len(atoms_list)
+            elif len(cooling_rates) != len(atoms_list):
+                raise ValueError(
+                    "cooling_rates must be omitted, a scalar, a single value to "
+                    "broadcast, or have the same length as paths."
+                )
 
         self.graphs = []
         for idx, atoms in enumerate(atoms_list):

--- a/ppmat/metrics/__init__.py
+++ b/ppmat/metrics/__init__.py
@@ -17,11 +17,13 @@ import copy
 import paddle  # noqa
 
 from ppmat.metrics.csp_metric import CSPMetric
+from ppmat.metrics.dm2_metric import DM2AmorphousGenerationMetric
 from ppmat.metrics.diffnmr_streaming_adapter import DiffNMRStreamingAdapter
 
 __all__ = [
     "build_metric",
     "CSPMetric",
+    "DM2AmorphousGenerationMetric",
     "DiffNMRStreamingAdapter",
     # "DiffNMRMetric",
     # "NLL", "CrossEntropyMetric", "SumExceptBatchMetric", "SumExceptBatchKL",

--- a/ppmat/metrics/dm2_metric.py
+++ b/ppmat/metrics/dm2_metric.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import glob
+from typing import Dict
+from typing import List
+from typing import Sequence
+from typing import Union
+
+import ase.io
+import numpy as np
+from ase import Atoms
+
+
+def _expand_paths(paths: Union[str, Sequence[str]]) -> List[str]:
+    if isinstance(paths, str):
+        paths = [paths]
+
+    expanded = []
+    for pattern in paths:
+        matches = sorted(glob.glob(pattern))
+        if not matches:
+            raise FileNotFoundError(f"No DM2 metric reference files matched: {pattern}")
+        expanded.extend(matches)
+    return expanded
+
+
+def _structure_array_to_atoms(structure_array: Dict) -> Atoms:
+    frac_coords = np.asarray(structure_array["frac_coords"], dtype=np.float64)
+    atom_types = np.asarray(structure_array["atom_types"], dtype=np.int64)
+    lattice = np.asarray(structure_array["lattice"], dtype=np.float64).reshape(3, 3)
+    return Atoms(
+        numbers=atom_types,
+        scaled_positions=frac_coords,
+        cell=lattice,
+        pbc=True,
+    )
+
+
+def _rdf_histogram(atoms_list: Sequence[Atoms], cutoff: float, bins: int):
+    hist = np.zeros(bins, dtype=np.float64)
+    for atoms in atoms_list:
+        distances = atoms.get_all_distances(mic=True)
+        upper = distances[np.triu_indices_from(distances, k=1)]
+        upper = upper[(upper > 1e-8) & (upper <= cutoff)]
+        values, _ = np.histogram(upper, bins=bins, range=(0.0, cutoff))
+        hist += values.astype(np.float64)
+    total = hist.sum()
+    if total > 0:
+        hist /= total
+    return hist
+
+
+def _wasserstein_1d_from_hist(hist_a, hist_b, cutoff: float):
+    bin_width = cutoff / len(hist_a)
+    return float(np.abs(np.cumsum(hist_a) - np.cumsum(hist_b)).sum() * bin_width)
+
+
+def _mean_coordination(
+    atoms_list: Sequence[Atoms],
+    center_atomic_number: int,
+    neighbor_atomic_number: int,
+    cutoff: float,
+):
+    values = []
+    for atoms in atoms_list:
+        numbers = np.asarray(atoms.numbers, dtype=np.int64)
+        center_mask = numbers == int(center_atomic_number)
+        neighbor_mask = numbers == int(neighbor_atomic_number)
+        if not np.any(center_mask):
+            continue
+        distances = atoms.get_all_distances(mic=True)
+        valid = (
+            (distances <= float(cutoff))
+            & (distances > 1e-8)
+            & neighbor_mask[None, :]
+        )
+        values.extend(valid[center_mask].sum(axis=1).tolist())
+    if not values:
+        return float("nan")
+    return float(np.mean(values))
+
+
+class DM2AmorphousGenerationMetric:
+    """RDF and coordination metrics for DM2 amorphous structure sampling."""
+
+    def __init__(
+        self,
+        reference_paths: Union[str, Sequence[str]],
+        file_format: str = "lammps-data",
+        rdf_cutoff: float = 8.0,
+        rdf_bins: int = 200,
+        coordination_cutoffs: Sequence[Dict] = (),
+    ):
+        self.reference_paths = _expand_paths(reference_paths)
+        self.file_format = file_format
+        self.rdf_cutoff = float(rdf_cutoff)
+        self.rdf_bins = int(rdf_bins)
+        self.coordination_cutoffs = list(coordination_cutoffs)
+        self.reference_atoms = [
+            ase.io.read(path, format=file_format) for path in self.reference_paths
+        ]
+        self.reference_rdf = _rdf_histogram(
+            self.reference_atoms,
+            cutoff=self.rdf_cutoff,
+            bins=self.rdf_bins,
+        )
+
+    def __call__(self, pred_structures: Sequence[Dict]):
+        pred_atoms = [_structure_array_to_atoms(item) for item in pred_structures]
+        pred_rdf = _rdf_histogram(
+            pred_atoms,
+            cutoff=self.rdf_cutoff,
+            bins=self.rdf_bins,
+        )
+
+        metric = {
+            "rdf_wasserstein": _wasserstein_1d_from_hist(
+                pred_rdf,
+                self.reference_rdf,
+                cutoff=self.rdf_cutoff,
+            )
+        }
+
+        for item in self.coordination_cutoffs:
+            name = item.get("name", "coordination")
+            pred_value = _mean_coordination(
+                pred_atoms,
+                center_atomic_number=item["center_atomic_number"],
+                neighbor_atomic_number=item["neighbor_atomic_number"],
+                cutoff=item["cutoff"],
+            )
+            ref_value = _mean_coordination(
+                self.reference_atoms,
+                center_atomic_number=item["center_atomic_number"],
+                neighbor_atomic_number=item["neighbor_atomic_number"],
+                cutoff=item["cutoff"],
+            )
+            metric[name] = pred_value
+            metric[f"{name}_reference"] = ref_value
+            metric[f"{name}_abs_diff"] = abs(pred_value - ref_value)
+
+        return metric

--- a/ppmat/models/__init__.py
+++ b/ppmat/models/__init__.py
@@ -29,6 +29,8 @@ from ppmat.models.comformer.comformer_graph_converter import ComformerGraphConve
 from ppmat.models.common.graph_converter import CrystalNN
 from ppmat.models.common.graph_converter import FindPointsInSpheres
 from ppmat.models.common.graph_converter import MolecularGraphConverter
+from ppmat.models.dm2.dm2 import DM2
+from ppmat.models.dm2.dm2 import DM2NequIPDenoiser
 from ppmat.models.diffcsp.diffcsp import DiffCSP
 from ppmat.models.diffnmr.diffnmr import DiffNMR
 from ppmat.models.diffnmr.diffnmr import DiffPrior
@@ -49,6 +51,8 @@ from ppmat.utils import save_load
 __all__ = [
     "iComformer",
     "ComformerGraphConverter",
+    "DM2",
+    "DM2NequIPDenoiser",
     "DiffCSP",
     "FindPointsInSpheres",
     "MEGNetPlus",

--- a/ppmat/models/common/e3nn/nn/_gate.py
+++ b/ppmat/models/common/e3nn/nn/_gate.py
@@ -30,7 +30,7 @@ class _Sortcut(paddle.nn.Layer):
             instructions += [tuple(range(i, i + len(irreps_out)))]
             i += len(irreps_out)
         assert len(irreps_in) == i, (len(irreps_in), i)
-        irreps_in, p, _ = paddle.sort(x=irreps_in), paddle.argsort(x=irreps_in)
+        irreps_in, p, _ = irreps_in.sort()
         instructions = [tuple(p[i] for i in x) for x in instructions]
         self.cut = Extract(irreps_in, self.irreps_outs, instructions)
         self.irreps_in = irreps_in.simplify()

--- a/ppmat/models/dm2/__init__.py
+++ b/ppmat/models/dm2/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ppmat.models.dm2.dm2 import DM2
+from ppmat.models.dm2.dm2 import DM2InitialEmbedding
+from ppmat.models.dm2.dm2 import DM2NequIPDenoiser
+from ppmat.models.dm2.dm2 import DownselectEdges
+from ppmat.models.dm2.dm2 import GaussianBasisEmbedding
+from ppmat.models.dm2.dm2 import RattleParticles
+
+__all__ = [
+    "DM2",
+    "DM2InitialEmbedding",
+    "DM2NequIPDenoiser",
+    "DownselectEdges",
+    "GaussianBasisEmbedding",
+    "RattleParticles",
+]

--- a/ppmat/models/dm2/dm2.py
+++ b/ppmat/models/dm2/dm2.py
@@ -1,0 +1,705 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This implementation adapts the DM2/graphite NequIP denoising design:
+# https://github.com/digital-synthesis-lab/DM2
+# Original DM2/graphite code is MIT licensed,
+# Copyright (c) 2022 Tim Hsu and (c) 2025 Digital Synthesis Lab @ UCLA.
+
+from __future__ import annotations
+
+import copy
+import math
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+
+import numpy as np
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+
+from ppmat.datasets.geometric_data_type.data import Data
+from ppmat.models.common.e3nn import o3
+from ppmat.models.common.e3nn.nn import FullyConnectedNet
+from ppmat.models.common.e3nn.nn import Gate
+from ppmat.utils.scatter import scatter
+
+
+def bessel(
+    x: paddle.Tensor,
+    start: float = 0.0,
+    end: float = 1.0,
+    num_basis: int = 8,
+    eps: float = 1e-5,
+) -> paddle.Tensor:
+    """Expand scalar distances with the Bessel basis used by DM2/graphite."""
+
+    x = x.unsqueeze(axis=-1) - start + eps
+    width = end - start
+    n = paddle.arange(1, num_basis + 1, dtype=x.dtype)
+    return ((2.0 / width) ** 0.5) * paddle.sin(n * math.pi * x / width) / x
+
+
+def tp_path_exists(irreps_in1, irreps_in2, ir_out) -> bool:
+    """Return whether a tensor-product path can produce ``ir_out``."""
+
+    irreps_in1 = o3.Irreps(irreps_in1).simplify()
+    irreps_in2 = o3.Irreps(irreps_in2).simplify()
+    ir_out = o3.Irrep(ir_out)
+
+    for _, ir1 in irreps_in1:
+        for _, ir2 in irreps_in2:
+            if ir_out in ir1 * ir2:
+                return True
+    return False
+
+
+class Compose(nn.Layer):
+    """Compose two e3nn layers while preserving irreps metadata."""
+
+    def __init__(self, first: nn.Layer, second: nn.Layer):
+        super().__init__()
+        self.first = first
+        self.second = second
+        self.irreps_in = self.first.irreps_in
+        self.irreps_out = self.second.irreps_out
+
+    def forward(self, *inputs):
+        return self.second(self.first(*inputs))
+
+
+class GaussianBasisEmbedding(nn.Layer):
+    """Embed scalar conditions with Gaussian basis functions.
+
+    DM2 uses this for the cooling-rate conditional model. The same module is also
+    useful for time or process-condition scalar conditioning.
+    """
+
+    def __init__(
+        self,
+        num_basis: int = 12,
+        embedding_dim: int = 32,
+        min_sigma: float = 0.1,
+        learn_means: bool = False,
+        learn_sigmas: bool = False,
+        min_value: float = 0.0,
+        max_value: float = 1.0,
+    ):
+        super().__init__()
+        means = paddle.linspace(min_value, max_value, num_basis, dtype="float32")
+        sigmas = paddle.ones_like(means) * max(min_sigma, 1.0 / (num_basis - 1))
+
+        if learn_means:
+            self.means = self.create_parameter(
+                shape=[num_basis],
+                default_initializer=nn.initializer.Assign(means),
+            )
+        else:
+            self.register_buffer("means", means)
+
+        if learn_sigmas:
+            self.sigmas = self.create_parameter(
+                shape=[num_basis],
+                default_initializer=nn.initializer.Assign(sigmas),
+            )
+        else:
+            self.register_buffer("sigmas", sigmas)
+
+        hidden_dim = max(embedding_dim * 2, num_basis)
+        self.layer1 = nn.Linear(num_basis, hidden_dim)
+        self.activation = nn.Softplus()
+        self.layer2 = nn.Linear(hidden_dim, embedding_dim)
+
+    def gaussian_basis(self, x: paddle.Tensor) -> paddle.Tensor:
+        if x.ndim == 1:
+            x = x.unsqueeze(axis=1)
+        x = x.astype(self.means.dtype)
+        x_expanded = x.expand([-1, self.means.shape[0]])
+        return paddle.exp(-0.5 * ((x_expanded - self.means) / self.sigmas) ** 2)
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        hidden = self.activation(self.layer1(self.gaussian_basis(x)))
+        return self.layer2(hidden)
+
+
+class DM2InitialEmbedding(nn.Layer):
+    """Initial species and edge-distance embedding used by DM2."""
+
+    def __init__(
+        self,
+        num_species: int,
+        cutoff: float,
+        node_embedding_dim: int = 8,
+        edge_basis_size: int = 16,
+    ):
+        super().__init__()
+        self.num_species = num_species
+        self.cutoff = cutoff
+        self.node_embedding_dim = node_embedding_dim
+        self.edge_basis_size = edge_basis_size
+        self.embed_node_x = nn.Embedding(num_species, node_embedding_dim)
+        self.embed_node_z = nn.Embedding(num_species, node_embedding_dim)
+
+    def forward(self, data: Data) -> Data:
+        node_species = data.x.astype("int64").reshape([-1])
+        data.h_node_x = self.embed_node_x(node_species)
+        data.h_node_z = self.embed_node_z(node_species)
+        edge_length = paddle.linalg.norm(data.edge_attr[:, :3], axis=-1)
+        data.h_edge = bessel(
+            edge_length,
+            start=0.0,
+            end=self.cutoff,
+            num_basis=self.edge_basis_size,
+        )
+        return data
+
+
+class DM2Interaction(nn.Layer):
+    """NequIP interaction layer adapted from the official DM2 graphite code."""
+
+    def __init__(
+        self,
+        irreps_in,
+        irreps_node,
+        irreps_edge,
+        irreps_out,
+        radial_neurons: Sequence[int] = (16, 64),
+        num_neighbors: float = 1.0,
+    ):
+        super().__init__()
+        self.irreps_in = o3.Irreps(irreps_in)
+        self.irreps_node = o3.Irreps(irreps_node)
+        self.irreps_edge = o3.Irreps(irreps_edge)
+        self.irreps_out = o3.Irreps(irreps_out)
+        self.num_neighbors = num_neighbors
+
+        irreps_mid = []
+        instructions = []
+        for i, (mul, ir_in) in enumerate(self.irreps_in):
+            for j, (_, ir_edge) in enumerate(self.irreps_edge):
+                for ir_out in ir_in * ir_edge:
+                    if ir_out in self.irreps_out:
+                        k = len(irreps_mid)
+                        irreps_mid.append((mul, ir_out))
+                        instructions.append((i, j, k, "uvu", True))
+        irreps_mid = o3.Irreps(irreps_mid)
+        irreps_mid, permutation, _ = irreps_mid.sort()
+
+        if irreps_mid.dim <= 0:
+            raise ValueError(
+                f"irreps_in={self.irreps_in} times irreps_edge={self.irreps_edge} "
+                f"produces nothing in irreps_out={self.irreps_out}."
+            )
+
+        instructions = [
+            (i_1, i_2, permutation[i_out], mode, train)
+            for i_1, i_2, i_out, mode, train in instructions
+        ]
+
+        self.sc = o3.FullyConnectedTensorProduct(
+            self.irreps_in,
+            self.irreps_node,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        self.lin1 = o3.FullyConnectedTensorProduct(
+            self.irreps_in,
+            self.irreps_node,
+            self.irreps_in,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        self.conv = o3.TensorProduct(
+            self.irreps_in,
+            self.irreps_edge,
+            irreps_mid,
+            instructions,
+            internal_weights=False,
+            shared_weights=False,
+        )
+        self.lin2 = o3.FullyConnectedTensorProduct(
+            irreps_mid,
+            self.irreps_node,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        self.mlp = FullyConnectedNet(
+            list(radial_neurons) + [self.conv.weight_numel],
+            F.silu,
+        )
+
+        self.alpha = o3.FullyConnectedTensorProduct(
+            irreps_mid,
+            self.irreps_node,
+            "0e",
+            internal_weights=True,
+            shared_weights=True,
+        )
+        with paddle.no_grad():
+            self.alpha.weight.set_value(paddle.zeros_like(self.alpha.weight))
+        if float(self.alpha.output_mask[0].item()) != 1.0:
+            raise ValueError(
+                f"irreps_mid={irreps_mid} and irreps_node={self.irreps_node} "
+                "are not able to generate scalar skip weights."
+            )
+
+    def forward(
+        self,
+        x: paddle.Tensor,
+        node_attr: paddle.Tensor,
+        edge_index: paddle.Tensor,
+        edge_attr: paddle.Tensor,
+        edge_len_emb: paddle.Tensor,
+    ) -> paddle.Tensor:
+        src, dst = edge_index[0], edge_index[1]
+        num_nodes = x.shape[0]
+
+        node_self_connection = self.sc(x, node_attr)
+        node_features = self.lin1(x, node_attr)
+        edge_features = self.conv(
+            node_features[src],
+            edge_attr,
+            weight=self.mlp(edge_len_emb),
+        )
+        node_features = scatter(
+            edge_features,
+            dst,
+            dim=0,
+            dim_size=num_nodes,
+            reduce="sum",
+        ) / (self.num_neighbors**0.5)
+        node_conv_out = self.lin2(node_features, node_attr)
+
+        alpha = self.alpha(node_features, node_attr)
+        mask = self.sc.output_mask
+        alpha = (1.0 - mask) + alpha * mask
+        return node_self_connection + alpha * node_conv_out
+
+
+class DM2NequIPDenoiser(nn.Layer):
+    """Paddle implementation of the DM2 NequIP denoiser.
+
+    The model follows ``digital-synthesis-lab/DM2``: species embeddings and
+    Bessel edge-distance features are passed through gated NequIP interactions
+    and a vector output head predicts Cartesian displacements/noise.
+    """
+
+    def __init__(
+        self,
+        num_species: int,
+        cutoff: float = 5.0,
+        node_embedding_dim: int = 8,
+        edge_basis_size: int = 16,
+        irreps_node_x: Optional[str] = None,
+        irreps_node_z: Optional[str] = None,
+        irreps_hidden: str = "64x0e + 32x1e",
+        irreps_edge: str = "4x0e + 4x1e + 2x2e",
+        irreps_out: str = "1x1e",
+        num_convs: int = 3,
+        radial_neurons: Sequence[int] = (16, 64),
+        num_neighbors: float = 12.0,
+        use_condition: bool = False,
+        condition_key: str = "cooling_rate",
+        condition_num_basis: int = 9,
+        condition_min: float = -4.0,
+        condition_max: float = 4.0,
+        condition_min_sigma: float = 0.6,
+    ):
+        super().__init__()
+        self.num_species = num_species
+        self.cutoff = cutoff
+        self.use_condition = use_condition
+        self.condition_key = condition_key
+
+        if irreps_node_x is None:
+            irreps_node_x = f"{node_embedding_dim}x0e"
+        if irreps_node_z is None:
+            irreps_node_z = f"{node_embedding_dim}x0e"
+
+        self.init_embed = DM2InitialEmbedding(
+            num_species=num_species,
+            cutoff=cutoff,
+            node_embedding_dim=node_embedding_dim,
+            edge_basis_size=edge_basis_size,
+        )
+        self.irreps_node_x = o3.Irreps(irreps_node_x)
+        self.irreps_node_z = o3.Irreps(irreps_node_z)
+        self.irreps_hidden = o3.Irreps(irreps_hidden)
+        self.irreps_edge = o3.Irreps(irreps_edge)
+        self.irreps_out = o3.Irreps(irreps_out)
+        self.num_convs = num_convs
+
+        act_scalars = {1: F.silu, -1: paddle.tanh}
+        act_gates = {1: F.sigmoid, -1: paddle.tanh}
+
+        irreps = self.irreps_node_x
+        self.interactions = nn.LayerList()
+        for _ in range(num_convs):
+            irreps_scalars = o3.Irreps(
+                [
+                    (mul, ir)
+                    for mul, ir in self.irreps_hidden
+                    if ir.l == 0 and tp_path_exists(irreps, self.irreps_edge, ir)
+                ]
+            )
+            irreps_gated = o3.Irreps(
+                [
+                    (mul, ir)
+                    for mul, ir in self.irreps_hidden
+                    if ir.l > 0 and tp_path_exists(irreps, self.irreps_edge, ir)
+                ]
+            )
+
+            if irreps_gated.dim > 0:
+                if tp_path_exists(self.irreps_node_z, self.irreps_edge, "0e"):
+                    gate_ir = "0e"
+                elif tp_path_exists(self.irreps_node_z, self.irreps_edge, "0o"):
+                    gate_ir = "0o"
+                else:
+                    raise ValueError(
+                        f"irreps={irreps} times irreps_edge={self.irreps_edge} "
+                        f"cannot produce gates for irreps_gated={irreps_gated}."
+                    )
+            else:
+                gate_ir = None
+            irreps_gates = o3.Irreps(
+                [(mul, gate_ir) for mul, _ in irreps_gated]
+            ).simplify()
+            gate = Gate(
+                irreps_scalars,
+                [act_scalars[ir.p] for _, ir in irreps_scalars],
+                irreps_gates,
+                [act_gates[ir.p] for _, ir in irreps_gates],
+                irreps_gated,
+            )
+            conv = DM2Interaction(
+                irreps_in=irreps,
+                irreps_node=self.irreps_node_z,
+                irreps_edge=self.irreps_edge,
+                irreps_out=gate.irreps_in,
+                radial_neurons=radial_neurons,
+                num_neighbors=num_neighbors,
+            )
+            irreps = gate.irreps_out
+            self.interactions.append(Compose(conv, gate))
+
+        self.hidden_irreps = irreps
+        self.out = o3.FullyConnectedTensorProduct(
+            irreps,
+            self.irreps_node_z,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+        )
+
+        if self.use_condition:
+            condition_embed_dim = max(1, irreps.dim // 4)
+            self.condition_embedding = GaussianBasisEmbedding(
+                num_basis=condition_num_basis,
+                embedding_dim=condition_embed_dim,
+                min_value=condition_min,
+                max_value=condition_max,
+                min_sigma=condition_min_sigma,
+            )
+            self.condition_projection = nn.Sequential(
+                nn.Linear(condition_embed_dim, condition_embed_dim),
+                nn.Silu(),
+                nn.Linear(condition_embed_dim, irreps.dim),
+            )
+        else:
+            self.condition_embedding = None
+            self.condition_projection = None
+
+    def _node_condition(
+        self,
+        data: Data,
+        condition: Optional[paddle.Tensor],
+        num_nodes: int,
+    ) -> Optional[paddle.Tensor]:
+        if not self.use_condition:
+            return None
+        if condition is None:
+            condition = getattr(data, self.condition_key, None)
+        if condition is None:
+            raise ValueError(
+                f"DM2 conditional denoiser expects condition '{self.condition_key}'."
+            )
+        condition = condition.reshape([-1, 1]).astype("float32")
+        condition_embedding = self.condition_embedding(condition)
+
+        batch = getattr(data, "batch", None)
+        if batch is None:
+            condition_embedding = condition_embedding[:1].expand([num_nodes, -1])
+        else:
+            condition_embedding = condition_embedding[batch]
+        return self.condition_projection(condition_embedding)
+
+    def forward(
+        self,
+        data: Data,
+        condition: Optional[paddle.Tensor] = None,
+    ) -> paddle.Tensor:
+        data = self.init_embed(data)
+        edge_index, edge_attr = data.edge_index, data.edge_attr[:, :3]
+        h_node_x, h_node_z, h_edge = data.h_node_x, data.h_node_z, data.h_edge
+
+        condition_embedding = self._node_condition(data, condition, h_node_x.shape[0])
+        edge_sh = o3.spherical_harmonics(
+            self.irreps_edge,
+            edge_attr,
+            normalize=True,
+            normalization="component",
+        )
+        for layer in self.interactions:
+            h_node_x = layer(h_node_x, h_node_z, edge_index, edge_sh, h_edge)
+            if condition_embedding is not None:
+                h_node_x = h_node_x + condition_embedding
+        return self.out(h_node_x, h_node_z)
+
+
+class RattleParticles(nn.Layer):
+    """Apply Gaussian position noise and store the target displacement ``dx``."""
+
+    def __init__(self, sigma_max: float, sigma_min: float = 0.001):
+        super().__init__()
+        self.sigma_min = sigma_min
+        self.sigma_max = sigma_max
+
+    def _sample_sigma(self, shape, dtype):
+        if self.sigma_min >= self.sigma_max:
+            return paddle.full(shape, self.sigma_max, dtype=dtype)
+        return paddle.empty(shape, dtype=dtype).uniform_(
+            min=self.sigma_min,
+            max=self.sigma_max,
+        )
+
+    def forward(self, data: Data) -> Data:
+        batch = getattr(data, "batch", None)
+        if batch is None:
+            sigma = self._sample_sigma([1], data.pos.dtype)
+            sigma = sigma.expand([data.pos.shape[0]]).unsqueeze(axis=-1)
+        else:
+            num_graphs = int(batch.max()) + 1 if batch.numel() > 0 else 1
+            sigma = self._sample_sigma([num_graphs], data.pos.dtype)
+            sigma = sigma[batch].unsqueeze(axis=-1)
+
+        eps = paddle.randn(data.pos.shape, dtype=data.pos.dtype)
+        data.dx = sigma * eps
+        data.pos = data.pos + data.dx
+
+        if getattr(data, "edge_attr", None) is not None:
+            src, dst = data.edge_index[0], data.edge_index[1]
+            data.edge_attr = data.edge_attr + data.dx[dst] - data.dx[src]
+
+        data.sigma = sigma
+        data.eps = eps
+        return data
+
+
+class DownselectEdges(nn.Layer):
+    """Keep only edges whose displacement length is within ``cutoff``."""
+
+    def __init__(self, cutoff: float):
+        super().__init__()
+        self.cutoff = cutoff
+
+    def forward(self, data: Data) -> Data:
+        edge_length = paddle.linalg.norm(data.edge_attr[:, :3], axis=1)
+        edge_ids = paddle.nonzero(edge_length <= self.cutoff).flatten()
+        data.edge_index = paddle.index_select(data.edge_index, edge_ids, axis=1)
+        data.edge_attr = paddle.index_select(data.edge_attr, edge_ids, axis=0)
+        return data
+
+
+def _get_graph_from_batch(batch) -> Data:
+    if isinstance(batch, Data):
+        return batch
+    if isinstance(batch, dict):
+        for key in ("dm2_graph", "graph", "data"):
+            graph = batch.get(key)
+            if isinstance(graph, Data):
+                return graph
+    raise TypeError(
+        "DM2 expects a geometric Data/Batch object or a dict containing "
+        "'dm2_graph', 'graph', or 'data'."
+    )
+
+
+def _get_condition_from_batch(
+    batch,
+    graph: Data,
+    condition_key: str,
+) -> Optional[paddle.Tensor]:
+    if hasattr(graph, condition_key):
+        return getattr(graph, condition_key)
+    if isinstance(batch, dict) and condition_key in batch:
+        return batch[condition_key]
+    return None
+
+
+def _clone_graph(data: Data) -> Data:
+    return data.clone() if hasattr(data, "clone") else copy.deepcopy(data)
+
+
+def _apply_position_update(data: Data, new_pos: paddle.Tensor) -> Data:
+    delta = new_pos - data.pos
+    data.pos = new_pos
+    if getattr(data, "edge_attr", None) is not None:
+        src, dst = data.edge_index[0], data.edge_index[1]
+        data.edge_attr = data.edge_attr + delta[dst] - delta[src]
+    return data
+
+
+def _get_lattice(data: Data, graph_id: int = 0) -> paddle.Tensor:
+    lattice = getattr(data, "lattice", None)
+    if lattice is None:
+        lattice = getattr(data, "cell", None)
+    if lattice is None:
+        return paddle.eye(3, dtype=data.pos.dtype)
+    if lattice.ndim == 2:
+        return lattice
+    return lattice[graph_id]
+
+
+def _graph_to_structure_arrays(data: Data) -> List[Dict[str, np.ndarray]]:
+    batch = getattr(data, "batch", None)
+    if batch is None:
+        batch = paddle.zeros([data.pos.shape[0]], dtype="int64")
+    num_graphs = int(batch.max()) + 1 if batch.numel() > 0 else 1
+
+    atom_types = getattr(data, "atomic_numbers", None)
+    if atom_types is None:
+        atom_types = data.x.astype("int64") + 1
+
+    results = []
+    for graph_id in range(num_graphs):
+        node_ids = paddle.nonzero(batch == graph_id).flatten()
+        pos = paddle.index_select(data.pos, node_ids, axis=0)
+        lattice = _get_lattice(data, graph_id).astype(pos.dtype)
+        frac_coords = pos @ paddle.linalg.inv(lattice)
+        frac_coords = frac_coords - paddle.floor(frac_coords)
+        graph_atom_types = paddle.index_select(atom_types, node_ids, axis=0)
+        results.append(
+            {
+                "frac_coords": frac_coords.numpy(),
+                "atom_types": graph_atom_types.numpy().astype("int64"),
+                "lattice": lattice.numpy(),
+            }
+        )
+    return results
+
+
+class DM2(nn.Layer):
+    """DM2 diffusion-style denoising model for disordered materials.
+
+    Training follows the official DM2 demos: random Gaussian ``rattle`` noise is
+    added to atom positions, short edges are selected, and the denoiser learns to
+    predict the displacement target. Sampling iteratively denoises a supplied
+    noisy/random periodic structure.
+    """
+
+    def __init__(
+        self,
+        denoiser_cfg: Dict,
+        cutoff: float = 5.0,
+        sigma_min: float = 0.001,
+        sigma_max: float = 0.75,
+        loss_weight: float = 1.0,
+        condition_key: str = "cooling_rate",
+    ):
+        super().__init__()
+        denoiser_cfg = dict(denoiser_cfg)
+        denoiser_cfg.setdefault("cutoff", cutoff)
+        denoiser_cfg.setdefault("condition_key", condition_key)
+        self.denoiser = DM2NequIPDenoiser(**denoiser_cfg)
+        self.cutoff = cutoff
+        self.sigma_min = sigma_min
+        self.sigma_max = sigma_max
+        self.loss_weight = loss_weight
+        self.condition_key = condition_key
+        self.rattle_particles = RattleParticles(
+            sigma_min=sigma_min,
+            sigma_max=sigma_max,
+        )
+        self.downselect_edges = DownselectEdges(cutoff)
+
+    def forward(self, batch, **kwargs):
+        graph = _clone_graph(_get_graph_from_batch(batch))
+        condition = _get_condition_from_batch(batch, graph, self.condition_key)
+        graph = self.rattle_particles(graph)
+        graph = self.downselect_edges(graph)
+        pred_dx = self.denoiser(graph, condition=condition)
+
+        loss_dx = F.mse_loss(pred_dx, graph.dx)
+        loss = self.loss_weight * loss_dx
+        return {
+            "loss_dict": {
+                "loss": loss,
+                "loss_dx": loss_dx,
+            },
+            "pred_dict": {
+                "dx": pred_dx,
+            },
+        }
+
+    @paddle.no_grad()
+    def sample(
+        self,
+        batch_data,
+        num_inference_steps: int = 100,
+        final_relax_steps: int = 0,
+        max_sigma_for_denoising: Optional[float] = None,
+        return_trajectory: bool = False,
+        **kwargs,
+    ):
+        graph = _clone_graph(_get_graph_from_batch(batch_data))
+        condition = _get_condition_from_batch(batch_data, graph, self.condition_key)
+        max_sigma = (
+            self.sigma_max
+            if max_sigma_for_denoising is None
+            else max_sigma_for_denoising
+        )
+
+        trajectory = []
+        sigmas = paddle.linspace(max_sigma, self.sigma_min, num_inference_steps)
+        for sigma in sigmas:
+            sigma_value = float(sigma.item())
+            noisy_graph = _clone_graph(graph)
+            noisy_graph = RattleParticles(
+                sigma_min=sigma_value,
+                sigma_max=sigma_value,
+            )(noisy_graph)
+            noisy_graph = self.downselect_edges(noisy_graph)
+            pred_dx = self.denoiser(noisy_graph, condition=condition)
+            graph = noisy_graph
+            graph = _apply_position_update(graph, noisy_graph.pos - pred_dx)
+            if return_trajectory:
+                trajectory.append(_graph_to_structure_arrays(graph))
+
+        for _ in range(final_relax_steps):
+            work_graph = self.downselect_edges(_clone_graph(graph))
+            pred_dx = self.denoiser(work_graph, condition=condition)
+            graph = work_graph
+            graph = _apply_position_update(graph, graph.pos - pred_dx)
+            if return_trajectory:
+                trajectory.append(_graph_to_structure_arrays(graph))
+
+        result = {"result": _graph_to_structure_arrays(graph)}
+        if return_trajectory:
+            result["trajectory"] = trajectory
+        return result

--- a/ppmat/models/dm2/dm2.py
+++ b/ppmat/models/dm2/dm2.py
@@ -35,6 +35,10 @@ from ppmat.datasets.geometric_data_type.data import Data
 from ppmat.models.common.e3nn import o3
 from ppmat.models.common.e3nn.nn import FullyConnectedNet
 from ppmat.models.common.e3nn.nn import Gate
+from ppmat.schedulers import build_scheduler
+from ppmat.schedulers.scheduling_dm2 import DM2DenoisingScheduler
+from ppmat.schedulers.scheduling_dm2 import DownselectEdges
+from ppmat.schedulers.scheduling_dm2 import RattleParticles
 from ppmat.utils.scatter import scatter
 
 
@@ -472,60 +476,6 @@ class DM2NequIPDenoiser(nn.Layer):
         return self.out(h_node_x, h_node_z)
 
 
-class RattleParticles(nn.Layer):
-    """Apply Gaussian position noise and store the target displacement ``dx``."""
-
-    def __init__(self, sigma_max: float, sigma_min: float = 0.001):
-        super().__init__()
-        self.sigma_min = sigma_min
-        self.sigma_max = sigma_max
-
-    def _sample_sigma(self, shape, dtype):
-        if self.sigma_min >= self.sigma_max:
-            return paddle.full(shape, self.sigma_max, dtype=dtype)
-        return paddle.empty(shape, dtype=dtype).uniform_(
-            min=self.sigma_min,
-            max=self.sigma_max,
-        )
-
-    def forward(self, data: Data) -> Data:
-        batch = getattr(data, "batch", None)
-        if batch is None:
-            sigma = self._sample_sigma([1], data.pos.dtype)
-            sigma = sigma.expand([data.pos.shape[0]]).unsqueeze(axis=-1)
-        else:
-            num_graphs = int(batch.max()) + 1 if batch.numel() > 0 else 1
-            sigma = self._sample_sigma([num_graphs], data.pos.dtype)
-            sigma = sigma[batch].unsqueeze(axis=-1)
-
-        eps = paddle.randn(data.pos.shape, dtype=data.pos.dtype)
-        data.dx = sigma * eps
-        data.pos = data.pos + data.dx
-
-        if getattr(data, "edge_attr", None) is not None:
-            src, dst = data.edge_index[0], data.edge_index[1]
-            data.edge_attr = data.edge_attr + data.dx[dst] - data.dx[src]
-
-        data.sigma = sigma
-        data.eps = eps
-        return data
-
-
-class DownselectEdges(nn.Layer):
-    """Keep only edges whose displacement length is within ``cutoff``."""
-
-    def __init__(self, cutoff: float):
-        super().__init__()
-        self.cutoff = cutoff
-
-    def forward(self, data: Data) -> Data:
-        edge_length = paddle.linalg.norm(data.edge_attr[:, :3], axis=1)
-        edge_ids = paddle.nonzero(edge_length <= self.cutoff).flatten()
-        data.edge_index = paddle.index_select(data.edge_index, edge_ids, axis=1)
-        data.edge_attr = paddle.index_select(data.edge_attr, edge_ids, axis=0)
-        return data
-
-
 def _get_graph_from_batch(batch) -> Data:
     if isinstance(batch, Data):
         return batch
@@ -621,6 +571,7 @@ class DM2(nn.Layer):
         sigma_max: float = 0.75,
         loss_weight: float = 1.0,
         condition_key: str = "cooling_rate",
+        scheduler_cfg: Optional[Dict] = None,
     ):
         super().__init__()
         denoiser_cfg = dict(denoiser_cfg)
@@ -632,10 +583,22 @@ class DM2(nn.Layer):
         self.sigma_max = sigma_max
         self.loss_weight = loss_weight
         self.condition_key = condition_key
-        self.rattle_particles = RattleParticles(
-            sigma_min=sigma_min,
-            sigma_max=sigma_max,
-        )
+        if scheduler_cfg is None:
+            self.scheduler = DM2DenoisingScheduler(
+                sigma_min=sigma_min,
+                sigma_max=sigma_max,
+            )
+        elif "__class_name__" in scheduler_cfg:
+            scheduler_cfg = copy.deepcopy(scheduler_cfg)
+            scheduler_cfg["__init_params__"].setdefault("sigma_min", sigma_min)
+            scheduler_cfg["__init_params__"].setdefault("sigma_max", sigma_max)
+            self.scheduler = build_scheduler(scheduler_cfg)
+        else:
+            scheduler_cfg = copy.deepcopy(scheduler_cfg)
+            scheduler_cfg.setdefault("sigma_min", sigma_min)
+            scheduler_cfg.setdefault("sigma_max", sigma_max)
+            self.scheduler = DM2DenoisingScheduler(**scheduler_cfg)
+        self.rattle_particles = self.scheduler
         self.downselect_edges = DownselectEdges(cutoff)
 
     def forward(self, batch, **kwargs):
@@ -661,33 +624,37 @@ class DM2(nn.Layer):
     def sample(
         self,
         batch_data,
-        num_inference_steps: int = 100,
-        final_relax_steps: int = 0,
+        num_inference_steps: Optional[int] = None,
+        final_relax_steps: Optional[int] = None,
         max_sigma_for_denoising: Optional[float] = None,
         return_trajectory: bool = False,
         **kwargs,
     ):
         graph = _clone_graph(_get_graph_from_batch(batch_data))
         condition = _get_condition_from_batch(batch_data, graph, self.condition_key)
-        max_sigma = (
-            self.sigma_max
-            if max_sigma_for_denoising is None
-            else max_sigma_for_denoising
+        final_relax_steps = (
+            self.scheduler.default_final_relax_steps
+            if final_relax_steps is None
+            else int(final_relax_steps)
         )
 
         trajectory = []
-        sigmas = paddle.linspace(max_sigma, self.sigma_min, num_inference_steps)
+        sigmas = self.scheduler.get_sampling_sigmas(
+            num_inference_steps=num_inference_steps,
+            max_sigma_for_denoising=max_sigma_for_denoising,
+            dtype=graph.pos.dtype,
+        )
         for sigma in sigmas:
             sigma_value = float(sigma.item())
             noisy_graph = _clone_graph(graph)
-            noisy_graph = RattleParticles(
-                sigma_min=sigma_value,
-                sigma_max=sigma_value,
-            )(noisy_graph)
+            noisy_graph = self.scheduler.add_noise(noisy_graph, sigma=sigma_value)
             noisy_graph = self.downselect_edges(noisy_graph)
             pred_dx = self.denoiser(noisy_graph, condition=condition)
             graph = noisy_graph
-            graph = _apply_position_update(graph, noisy_graph.pos - pred_dx)
+            graph = _apply_position_update(
+                graph,
+                self.scheduler.denoise_step(noisy_graph.pos, pred_dx),
+            )
             if return_trajectory:
                 trajectory.append(_graph_to_structure_arrays(graph))
 
@@ -695,7 +662,10 @@ class DM2(nn.Layer):
             work_graph = self.downselect_edges(_clone_graph(graph))
             pred_dx = self.denoiser(work_graph, condition=condition)
             graph = work_graph
-            graph = _apply_position_update(graph, graph.pos - pred_dx)
+            graph = _apply_position_update(
+                graph,
+                self.scheduler.denoise_step(graph.pos, pred_dx),
+            )
             if return_trajectory:
                 trajectory.append(_graph_to_structure_arrays(graph))
 

--- a/ppmat/schedulers/__init__.py
+++ b/ppmat/schedulers/__init__.py
@@ -16,6 +16,7 @@ import copy
 from typing import Dict
 
 import ppmat.schedulers.scheduling_wrapped_sde_ve as scheduling_wrapped_sde_ve  # noqa
+from ppmat.schedulers.scheduling_dm2 import DM2DenoisingScheduler
 from ppmat.schedulers.scheduling_d3pm import D3PMScheduler
 from ppmat.schedulers.scheduling_ddpm import DDPMScheduler
 from ppmat.schedulers.scheduling_diffprior import NoiseScheduler
@@ -34,6 +35,7 @@ __all__ = [
     "LatticeVPSDEScheduler",
     "NumAtomsVarianceAdjustedWrappedVESDE",
     "D3PMScheduler",
+    "DM2DenoisingScheduler",
     "NoiseScheduler",
 ]
 

--- a/ppmat/schedulers/scheduling_dm2.py
+++ b/ppmat/schedulers/scheduling_dm2.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import paddle
+
+
+class DM2DenoisingScheduler:
+    """Noise and denoising schedule used by DM2.
+
+    The official DM2 demos train the denoiser by applying Gaussian rattle noise to
+    periodic structures and sampling by repeatedly denoising noisy snapshots. This
+    class keeps those diffusion-related pieces outside the model definition so DM2
+    follows the scheduler layout used by the other generative models in PPMat.
+    """
+
+    def __init__(
+        self,
+        sigma_min: float = 0.001,
+        sigma_max: float = 0.75,
+        train_sigma_distribution: str = "uniform",
+        sample_schedule: str = "linear",
+        default_num_inference_steps: int = 2900,
+        default_final_relax_steps: int = 100,
+        default_max_sigma_for_denoising: float = 1.0,
+    ):
+        self.sigma_min = float(sigma_min)
+        self.sigma_max = float(sigma_max)
+        self.train_sigma_distribution = train_sigma_distribution
+        self.sample_schedule = sample_schedule
+        self.default_num_inference_steps = int(default_num_inference_steps)
+        self.default_final_relax_steps = int(default_final_relax_steps)
+        self.default_max_sigma_for_denoising = float(default_max_sigma_for_denoising)
+
+    def _sample_sigma(self, shape, dtype):
+        if self.sigma_min >= self.sigma_max:
+            return paddle.full(shape, self.sigma_max, dtype=dtype)
+
+        if self.train_sigma_distribution == "uniform":
+            return paddle.empty(shape, dtype=dtype).uniform_(
+                min=self.sigma_min,
+                max=self.sigma_max,
+            )
+
+        if self.train_sigma_distribution in {"log_uniform", "loguniform"}:
+            log_sigma = paddle.empty(shape, dtype=dtype).uniform_(
+                min=math.log(self.sigma_min),
+                max=math.log(self.sigma_max),
+            )
+            return paddle.exp(log_sigma)
+
+        raise ValueError(
+            "train_sigma_distribution must be 'uniform' or 'log_uniform', "
+            f"got {self.train_sigma_distribution}."
+        )
+
+    def _expand_sigma_to_nodes(self, data, sigma: Optional[paddle.Tensor]):
+        batch = getattr(data, "batch", None)
+        num_nodes = data.pos.shape[0]
+
+        if sigma is None:
+            if batch is None:
+                sigma = self._sample_sigma([1], data.pos.dtype)
+                return sigma.expand([num_nodes]).unsqueeze(axis=-1)
+
+            num_graphs = int(batch.max()) + 1 if batch.numel() > 0 else 1
+            sigma = self._sample_sigma([num_graphs], data.pos.dtype)
+            return sigma[batch].unsqueeze(axis=-1)
+
+        if not isinstance(sigma, paddle.Tensor):
+            sigma = paddle.to_tensor(sigma, dtype=data.pos.dtype)
+        sigma = sigma.astype(data.pos.dtype).reshape([-1])
+
+        if sigma.numel() == 1:
+            return sigma.expand([num_nodes]).unsqueeze(axis=-1)
+        if sigma.shape[0] == num_nodes:
+            return sigma.unsqueeze(axis=-1)
+        if batch is not None:
+            num_graphs = int(batch.max()) + 1 if batch.numel() > 0 else 1
+            if sigma.shape[0] == num_graphs:
+                return sigma[batch].unsqueeze(axis=-1)
+
+        raise ValueError(
+            "sigma must be a scalar, one value per graph, or one value per node."
+        )
+
+    def add_noise(self, data, sigma: Optional[paddle.Tensor] = None):
+        """Apply Gaussian rattle noise and store ``dx``, ``eps`` and ``sigma``."""
+
+        sigma_per_node = self._expand_sigma_to_nodes(data, sigma)
+        eps = paddle.randn(data.pos.shape, dtype=data.pos.dtype)
+        data.dx = sigma_per_node * eps
+        data.pos = data.pos + data.dx
+
+        if getattr(data, "edge_attr", None) is not None:
+            src, dst = data.edge_index[0], data.edge_index[1]
+            data.edge_attr = data.edge_attr + data.dx[dst] - data.dx[src]
+
+        data.sigma = sigma_per_node
+        data.eps = eps
+        return data
+
+    __call__ = add_noise
+
+    def get_sampling_sigmas(
+        self,
+        num_inference_steps: Optional[int] = None,
+        max_sigma_for_denoising: Optional[float] = None,
+        dtype: str = "float32",
+    ):
+        num_steps = (
+            self.default_num_inference_steps
+            if num_inference_steps is None
+            else int(num_inference_steps)
+        )
+        max_sigma = (
+            self.default_max_sigma_for_denoising
+            if max_sigma_for_denoising is None
+            else float(max_sigma_for_denoising)
+        )
+
+        if self.sample_schedule == "linear":
+            return paddle.linspace(max_sigma, self.sigma_min, num_steps, dtype=dtype)
+
+        if self.sample_schedule in {"log", "log_linear"}:
+            return paddle.exp(
+                paddle.linspace(
+                    math.log(max_sigma),
+                    math.log(self.sigma_min),
+                    num_steps,
+                    dtype=dtype,
+                )
+            )
+
+        raise ValueError(
+            "sample_schedule must be 'linear' or 'log_linear', "
+            f"got {self.sample_schedule}."
+        )
+
+    def denoise_step(self, noisy_pos: paddle.Tensor, pred_dx: paddle.Tensor):
+        return noisy_pos - pred_dx
+
+
+class RattleParticles(paddle.nn.Layer):
+    """Compatibility wrapper around :class:`DM2DenoisingScheduler.add_noise`."""
+
+    def __init__(self, sigma_max: float, sigma_min: float = 0.001):
+        super().__init__()
+        self.scheduler = DM2DenoisingScheduler(
+            sigma_min=sigma_min,
+            sigma_max=sigma_max,
+        )
+
+    def forward(self, data):
+        return self.scheduler.add_noise(data)
+
+
+class DownselectEdges(paddle.nn.Layer):
+    """Keep only edges whose displacement length is within ``cutoff``."""
+
+    def __init__(self, cutoff: float):
+        super().__init__()
+        self.cutoff = cutoff
+
+    def forward(self, data):
+        edge_length = paddle.linalg.norm(data.edge_attr[:, :3], axis=1)
+        edge_ids = paddle.nonzero(edge_length <= self.cutoff).flatten()
+        data.edge_index = paddle.index_select(data.edge_index, edge_ids, axis=1)
+        data.edge_attr = paddle.index_select(data.edge_attr, edge_ids, axis=0)
+        return data

--- a/structure_generation/README.md
+++ b/structure_generation/README.md
@@ -6,31 +6,36 @@ The structure generation (SG) task tackles the inverse-design challenge of creat
 
 ## 2.Models Matrix
 
-| **Supported Functions**             | **[DiffCSP](./configs/diffcsp/README.md)** | **[MatterGen](./configs/mattergen/README.md)** |
-| ----------------------------------- | ------------------------------------------ | ---------------------------------------------- |
-| **Support Material Types**          |                                            |                                                |
-| Inorganic Materials                 |                    ✅                      |                       ✅                       |
-| **Structure Generation**            |                                            |                                                |
-| &emsp;Random Sample                 | ✅                                         | ✅                                             |
-| &emsp;Condition Sample              | ✅                                         | ✅                                             |
-| **ML Capabilities · Training**      |                                            |                                                |
-| &emsp;Single-GPU                    | ✅                                         | ✅                                             |
-| &emsp;Distributed Train             | ✅                                         | ✅                                             |
-| &emsp;Mixed Precision               | -                                          | -                                              |
-| &emsp;Fine-tuning                   | ✅                                         | ✅                                             |
-| &emsp;Uncertainty / Active-Learning | -                                          | -                                              |
-| &emsp;Dynamic→Static                | -                                          | -                                              |
-| &emsp;Compiler CINN                 | -                                          | -                                              |
-| **ML Capabilities · Predict**       |                                            |                                                |
-| &emsp;Distillation / Pruning        | -                                          | -                                              |
-| &emsp;Standard inference            | ✅                                         | ✅                                             |
-| &emsp;Distributed inference         | -                                          | -                                              |
-| &emsp;Compiler CINN                 | -                                          | -                                              |
-| **Dataset**                         |                                            |                                                |
-| **Materials Project**                |                                            |                                                |
-| &emsp;MP20                          | ✅                                         | ✅                                             |
-| **Hrbrid**                          |                                            |                                                |
-| &emsp;ALEX MP20                     | -                                          | ✅                                             |
-| **ML2DDB🌟**                        | -                                          | ✅                                             |
+| **Supported Functions**             | **[DiffCSP](./configs/diffcsp/README.md)** | **[MatterGen](./configs/mattergen/README.md)** | **[DM2](./configs/dm2/README.md)** |
+| ----------------------------------- | ------------------------------------------ | ---------------------------------------------- | ---------------------------------- |
+| **Support Material Types**          |                                            |                                                |                                    |
+| Inorganic Materials                 | ✅                                         | ✅                                             | -                                  |
+| Disordered / Amorphous Materials    | -                                          | -                                              | ✅                                 |
+| **Structure Generation**            |                                            |                                                |                                    |
+| &emsp;Random Sample                 | ✅                                         | ✅                                             | -                                  |
+| &emsp;Denoising Sample              | -                                          | -                                              | ✅                                 |
+| &emsp;Condition Sample              | ✅                                         | ✅                                             | -                                  |
+| &emsp;Process-condition Sample      | -                                          | -                                              | ✅                                 |
+| **ML Capabilities · Training**      |                                            |                                                |                                    |
+| &emsp;Single-GPU                    | ✅                                         | ✅                                             | ✅                                 |
+| &emsp;Distributed Train             | ✅                                         | ✅                                             | -                                  |
+| &emsp;Mixed Precision               | -                                          | -                                              | -                                  |
+| &emsp;Fine-tuning                   | ✅                                         | ✅                                             | -                                  |
+| &emsp;Uncertainty / Active-Learning | -                                          | -                                              | -                                  |
+| &emsp;Dynamic→Static                | -                                          | -                                              | -                                  |
+| &emsp;Compiler CINN                 | -                                          | -                                              | -                                  |
+| **ML Capabilities · Predict**       |                                            |                                                |                                    |
+| &emsp;Distillation / Pruning        | -                                          | -                                              | -                                  |
+| &emsp;Standard inference            | ✅                                         | ✅                                             | ✅                                 |
+| &emsp;Distributed inference         | -                                          | -                                              | -                                  |
+| &emsp;Compiler CINN                 | -                                          | -                                              | -                                  |
+| **Dataset**                         |                                            |                                                |                                    |
+| **Materials Project**               |                                            |                                                |                                    |
+| &emsp;MP20                          | ✅                                         | ✅                                             | -                                  |
+| **Hybrid**                          |                                            |                                                |                                    |
+| &emsp;ALEX MP20                     | -                                          | ✅                                             | -                                  |
+| **Disordered structures**           |                                            |                                                |                                    |
+| &emsp;ASE-readable trajectories      | -                                          | -                                              | ✅                                 |
+| **ML2DDB🌟**                        | -                                          | ✅                                             | -                                  |
 
 **Notice**:🌟 represent originate research work published from paddlematerials toolkit

--- a/structure_generation/configs/dm2/README.md
+++ b/structure_generation/configs/dm2/README.md
@@ -1,41 +1,108 @@
 # DM2
 
 [DM2: Diffusion Models for Disordered Materials](https://arxiv.org/abs/2507.05024)
-generates amorphous structures by learning a denoising vector field over periodic
-atomistic graphs. The PaddleMaterials implementation follows the official DM2
-training recipe:
+generates amorphous structures by learning an equivariant denoising vector field over
+periodic atomistic graphs. This PaddleMaterials implementation adapts the official
+`digital-synthesis-lab/DM2` demo recipe and integrates it with the PPMat trainer,
+sampler, dataset, scheduler and metric builders.
 
-- build a large-cutoff periodic graph from ASE structures;
-- perturb atom positions with Gaussian rattle noise;
-- downselect edges to the model cutoff;
-- train a NequIP-style equivariant denoiser to predict the Cartesian displacement;
-- iteratively denoise random or noisy structures for sampling.
+## Coverage
 
-## Data
+| System | Config | Condition | Metric target |
+| --- | --- | --- | --- |
+| a-SiO2 | [dm2_sio2_unconditional.yaml](dm2_sio2_unconditional.yaml) | none | RDF Wasserstein, Si-O coordination |
+| a-SiO2 | [dm2_sio2_conditional.yaml](dm2_sio2_conditional.yaml) | cooling rate | RDF Wasserstein, Si-O coordination |
+| Cu50Zr50 | [dm2_cuzr.yaml](dm2_cuzr.yaml) | none | RDF Wasserstein |
 
-Use `DM2StructureDataset` for ASE-readable files such as `lammps-data`, `extxyz`,
-or `cif`. The dataset encodes species as contiguous ids for embedding and keeps
-the original atomic numbers for writing sampled structures.
+`dm2_sio2.yaml` is kept as a compact backward-compatible SiO2 config.
 
-The Paddle implementation adapts the official DM2/graphite denoising design
-from `digital-synthesis-lab/DM2` (MIT licensed).
+## Data And Assets
 
-For conditional DM2, pass per-structure `cooling_rates`; by default the dataset
-stores `log10(cooling_rate)`, matching the official conditional demo.
+Use `DM2StructureDataset` for ASE-readable periodic structures such as
+`lammps-data`, `extxyz` or `cif`. The dataset encodes atomic species as contiguous
+ids for the embedding table and preserves the original atomic numbers for sampled
+structure export.
+
+Expected local layout:
+
+```text
+data/dm2/
+  sio2/
+    unconditional/{train,val,sample,reference}/
+    conditional/{train,val,sample,reference}/
+  cuzr/{train,val,sample,reference}/
+```
+
+The official PyTorch DM2 repository provides demo SiO2 training files, SiO2 random
+initial structures and three pretrained checkpoints:
+
+- `gen-a-sio2-uncond-v1.pt`
+- `gen-a-sio2-cond-v1.pt`
+- `gen-cu50zr50-v1.pt`
+
+For final Hackathon acceptance, upload the original dataset files, converted
+Paddle checkpoints and training logs through the PaddleMaterials maintainers'
+requested channel, then put the provided Baidu/BOS links here and in the PR:
+
+| Asset | Link |
+| --- | --- |
+| a-SiO2 unconditional data/checkpoint/log | TODO |
+| a-SiO2 conditional data/checkpoint/log | TODO |
+| Cu50Zr50 data/checkpoint/log | TODO |
 
 ## Training
 
-Update `paths`, `species`, and `cooling_rates` in `dm2_sio2.yaml`, then run:
-
 ```bash
-python structure_generation/train.py -c structure_generation/configs/dm2/dm2_sio2.yaml
+python structure_generation/train.py -c structure_generation/configs/dm2/dm2_sio2_unconditional.yaml
+python structure_generation/train.py -c structure_generation/configs/dm2/dm2_sio2_conditional.yaml
+python structure_generation/train.py -c structure_generation/configs/dm2/dm2_cuzr.yaml
 ```
 
-For unconditional training, keep `Model.__init_params__.denoiser_cfg.use_condition`
-as `false` and omit `cooling_rates` from the dataset.
+The default training recipe follows the official demos: large-cutoff graph
+construction, Gaussian rattle noise, cutoff edge down-selection, AdamW with
+learning rate `2e-4`, and displacement MSE loss.
 
-## Sampling
+## Sampling And Metrics
 
-Load a trained checkpoint through `structure_generation/sample.py` and provide a
-DM2 graph batch from the sample dataset section. Sampling returns structure-array
-dicts compatible with `BuildStructure(format="array")`.
+```bash
+python structure_generation/sample.py \
+  --config_path structure_generation/configs/dm2/dm2_sio2_unconditional.yaml \
+  --checkpoint_path ./output/dm2_sio2_unconditional/checkpoints/latest.pdparams \
+  --mode by_dataloader \
+  --save_path ./output/dm2_sio2_unconditional/samples
+
+python structure_generation/sample.py \
+  --config_path structure_generation/configs/dm2/dm2_sio2_unconditional.yaml \
+  --checkpoint_path ./output/dm2_sio2_unconditional/checkpoints/latest.pdparams \
+  --mode compute_metric
+```
+
+DM2 sampling uses graph batches from the `Sample.data` section. `by_num_atoms` and
+`by_chemical_formula` are not the recommended DM2 entrypoints because DM2 needs an
+initial periodic graph, not only a composition.
+
+## Validation Requirements
+
+Hackathon final review requires evidence beyond smoke tests:
+
+| Item | Requirement | Artifact |
+| --- | --- | --- |
+| Forward parity | Paddle vs official PyTorch score/displacement diff <= 1e-6 | parity script output or screenshot |
+| Backward parity | same data, 2+ epochs, aligned loss curve | train logs |
+| Sampling quality | generation metric error within 5% | RDF/coordination report |
+| Systems | a-SiO2 unconditional, a-SiO2 conditional, Cu50Zr50 | config + checkpoint + metric |
+
+This config directory provides the runnable PPMat entrypoints and metric hooks for
+those artifacts. The numeric reproduction results must be produced with the final
+uploaded data and checkpoints.
+
+## Citation
+
+```bibtex
+@article{yang2025generative,
+  title={A generative diffusion model for amorphous materials},
+  author={Yang, Kai and Schwalbe-Koda, Daniel},
+  journal={arXiv:2507.05024},
+  year={2025}
+}
+```

--- a/structure_generation/configs/dm2/README.md
+++ b/structure_generation/configs/dm2/README.md
@@ -1,0 +1,41 @@
+# DM2
+
+[DM2: Diffusion Models for Disordered Materials](https://arxiv.org/abs/2507.05024)
+generates amorphous structures by learning a denoising vector field over periodic
+atomistic graphs. The PaddleMaterials implementation follows the official DM2
+training recipe:
+
+- build a large-cutoff periodic graph from ASE structures;
+- perturb atom positions with Gaussian rattle noise;
+- downselect edges to the model cutoff;
+- train a NequIP-style equivariant denoiser to predict the Cartesian displacement;
+- iteratively denoise random or noisy structures for sampling.
+
+## Data
+
+Use `DM2StructureDataset` for ASE-readable files such as `lammps-data`, `extxyz`,
+or `cif`. The dataset encodes species as contiguous ids for embedding and keeps
+the original atomic numbers for writing sampled structures.
+
+The Paddle implementation adapts the official DM2/graphite denoising design
+from `digital-synthesis-lab/DM2` (MIT licensed).
+
+For conditional DM2, pass per-structure `cooling_rates`; by default the dataset
+stores `log10(cooling_rate)`, matching the official conditional demo.
+
+## Training
+
+Update `paths`, `species`, and `cooling_rates` in `dm2_sio2.yaml`, then run:
+
+```bash
+python structure_generation/train.py -c structure_generation/configs/dm2/dm2_sio2.yaml
+```
+
+For unconditional training, keep `Model.__init_params__.denoiser_cfg.use_condition`
+as `false` and omit `cooling_rates` from the dataset.
+
+## Sampling
+
+Load a trained checkpoint through `structure_generation/sample.py` and provide a
+DM2 graph batch from the sample dataset section. Sampling returns structure-array
+dicts compatible with `BuildStructure(format="array")`.

--- a/structure_generation/configs/dm2/dm2_cuzr.yaml
+++ b/structure_generation/configs/dm2/dm2_cuzr.yaml
@@ -1,3 +1,11 @@
+# DM2 Cu50Zr50 metallic-glass reproduction config.
+#
+# Expected data layout:
+#   data/dm2/cuzr/train/*.dat
+#   data/dm2/cuzr/val/*.dat
+#   data/dm2/cuzr/sample/*.dat
+#   data/dm2/cuzr/reference/*.dat
+
 Global:
   do_train: True
   do_eval: False
@@ -6,7 +14,7 @@ Global:
 Trainer:
   max_epochs: 200
   seed: 42
-  output_dir: ./output/dm2_sio2
+  output_dir: ./output/dm2_cuzr
   save_freq: 20
   log_freq: 10
   start_eval_epoch: 1
@@ -72,10 +80,10 @@ Dataset:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/train/*.dat"
+        paths: "./data/dm2/cuzr/train/*.dat"
         file_format: "lammps-data"
         cutoff: 10.0
-        species: [8, 14]
+        species: [29, 40]
         duplicate: 128
     loader:
       num_workers: 0
@@ -91,10 +99,10 @@ Dataset:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/val/*.dat"
+        paths: "./data/dm2/cuzr/val/*.dat"
         file_format: "lammps-data"
         cutoff: 10.0
-        species: [8, 14]
+        species: [29, 40]
         duplicate: 1
     loader:
       num_workers: 0
@@ -116,10 +124,10 @@ Sample:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/sample/*.dat"
+        paths: "./data/dm2/cuzr/sample/*.dat"
         file_format: "lammps-data"
         cutoff: 10.0
-        species: [8, 14]
+        species: [29, 40]
         duplicate: 1
     loader:
       num_workers: 0
@@ -139,13 +147,9 @@ Sample:
   metrics:
     __class_name__: DM2AmorphousGenerationMetric
     __init_params__:
-      reference_paths: "./data/dm2/sio2/reference/*.dat"
+      reference_paths: "./data/dm2/cuzr/reference/*.dat"
       file_format: "lammps-data"
       rdf_cutoff: 8.0
       rdf_bins: 200
-      coordination_cutoffs:
-        - name: si_o_coordination
-          center_atomic_number: 14
-          neighbor_atomic_number: 8
-          cutoff: 2.0
+      coordination_cutoffs: []
   post_transforms: null

--- a/structure_generation/configs/dm2/dm2_sio2.yaml
+++ b/structure_generation/configs/dm2/dm2_sio2.yaml
@@ -1,0 +1,125 @@
+Global:
+  do_train: True
+  do_eval: False
+  do_test: False
+
+Trainer:
+  max_epochs: 200
+  seed: 42
+  output_dir: ./output/dm2_sio2
+  save_freq: 20
+  log_freq: 10
+  start_eval_epoch: 1
+  eval_freq: 1
+  pretrained_model_path: null
+  resume_from_checkpoint: null
+  use_amp: False
+  amp_level: 'O1'
+  eval_with_no_grad: True
+  gradient_accumulation_steps: 1
+  best_metric_indicator: 'eval_loss'
+  name_for_best_metric: "loss"
+  greater_is_better: False
+  compute_metric_during_train: False
+  metric_strategy_during_eval: 'step'
+  use_visualdl: False
+  use_wandb: False
+  use_tensorboard: False
+
+Model:
+  __class_name__: DM2
+  __init_params__:
+    cutoff: 5.0
+    sigma_min: 0.001
+    sigma_max: 0.75
+    loss_weight: 1.0
+    condition_key: cooling_rate
+    denoiser_cfg:
+      num_species: 2
+      node_embedding_dim: 8
+      edge_basis_size: 16
+      irreps_hidden: "64x0e + 32x1e"
+      irreps_edge: "4x0e + 4x1e + 2x2e"
+      irreps_out: "1x1e"
+      num_convs: 3
+      radial_neurons: [16, 64]
+      num_neighbors: 12
+      use_condition: False
+
+Optimizer:
+  __class_name__: AdamW
+  __init_params__:
+    beta1: 0.9
+    beta2: 0.999
+    lr:
+      __class_name__: Cosine
+      __init_params__:
+        learning_rate: 0.0002
+        by_epoch: False
+
+Dataset:
+  train:
+    dataset:
+      __class_name__: DM2StructureDataset
+      __init_params__:
+        paths: "./data/dm2/sio2/train/*.dat"
+        file_format: "lammps-data"
+        cutoff: 10.0
+        species: [8, 14]
+        duplicate: 128
+    loader:
+      num_workers: 0
+      use_shared_memory: False
+      collate_fn: DefaultCollator
+    sampler:
+      __class_name__: BatchSampler
+      __init_params__:
+        shuffle: True
+        drop_last: False
+        batch_size: 16
+  val:
+    dataset:
+      __class_name__: DM2StructureDataset
+      __init_params__:
+        paths: "./data/dm2/sio2/val/*.dat"
+        file_format: "lammps-data"
+        cutoff: 10.0
+        species: [8, 14]
+        duplicate: 1
+    loader:
+      num_workers: 0
+      use_shared_memory: False
+      collate_fn: DefaultCollator
+    sampler:
+      __class_name__: BatchSampler
+      __init_params__:
+        shuffle: False
+        drop_last: False
+        batch_size: 8
+
+Sample:
+  data:
+    dataset:
+      __class_name__: DM2StructureDataset
+      __init_params__:
+        paths: "./data/dm2/sio2/sample/*.dat"
+        file_format: "lammps-data"
+        cutoff: 10.0
+        species: [8, 14]
+        duplicate: 1
+    loader:
+      num_workers: 0
+      use_shared_memory: False
+      collate_fn: DefaultCollator
+    sampler:
+      __class_name__: BatchSampler
+      __init_params__:
+        shuffle: False
+        drop_last: False
+        batch_size: 1
+  build_structure_cfg:
+    format: array
+    primitive: False
+    niggli: False
+    canocial: False
+  post_transforms: null

--- a/structure_generation/configs/dm2/dm2_sio2_conditional.yaml
+++ b/structure_generation/configs/dm2/dm2_sio2_conditional.yaml
@@ -1,3 +1,8 @@
+# DM2 a-SiO2 cooling-rate conditional reproduction config.
+#
+# Expected data layout follows the official DM2 conditional demo. Cooling rates are
+# stored as K/ps here and transformed to log10(cooling_rate) by DM2StructureDataset.
+
 Global:
   do_train: True
   do_eval: False
@@ -6,7 +11,7 @@ Global:
 Trainer:
   max_epochs: 200
   seed: 42
-  output_dir: ./output/dm2_sio2
+  output_dir: ./output/dm2_sio2_conditional
   save_freq: 20
   log_freq: 10
   start_eval_epoch: 1
@@ -44,7 +49,11 @@ Model:
       num_convs: 3
       radial_neurons: [16, 64]
       num_neighbors: 12
-      use_condition: False
+      use_condition: True
+      condition_num_basis: 9
+      condition_min: -4.0
+      condition_max: 4.0
+      condition_min_sigma: 0.6
     scheduler_cfg:
       __class_name__: DM2DenoisingScheduler
       __init_params__:
@@ -72,7 +81,57 @@ Dataset:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/train/*.dat"
+        paths:
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_100k_sample0.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_100k_sample1.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_100k_sample2.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_100k_sample3.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_100k_sample4.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_100k_sample5.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_10k_sample0.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_10k_sample1.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_10k_sample2.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_10k_sample3.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_10k_sample4.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_10k_sample5.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_1k_sample0.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_1k_sample1.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_1k_sample2.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_1k_sample3.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_1k_sample4.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_1k_sample5.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_0_1k_sample0.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_0_1k_sample1.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_0_1k_sample2.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_0_1k_sample3.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_0_1k_sample4.dat"
+          - "./data/dm2/sio2/conditional/train/sio2_3000_glass_0_1k_sample5.dat"
+        cooling_rates:
+          - 100.0
+          - 100.0
+          - 100.0
+          - 100.0
+          - 100.0
+          - 100.0
+          - 10.0
+          - 10.0
+          - 10.0
+          - 10.0
+          - 10.0
+          - 10.0
+          - 1.0
+          - 1.0
+          - 1.0
+          - 1.0
+          - 1.0
+          - 1.0
+          - 0.1
+          - 0.1
+          - 0.1
+          - 0.1
+          - 0.1
+          - 0.1
+        log10_cooling_rate: True
         file_format: "lammps-data"
         cutoff: 10.0
         species: [8, 14]
@@ -91,7 +150,9 @@ Dataset:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/val/*.dat"
+        paths: "./data/dm2/sio2/conditional/val/*.dat"
+        cooling_rates: [0.1]
+        log10_cooling_rate: True
         file_format: "lammps-data"
         cutoff: 10.0
         species: [8, 14]
@@ -116,7 +177,9 @@ Sample:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/sample/*.dat"
+        paths: "./data/dm2/sio2/conditional/sample/*.dat"
+        cooling_rates: [0.1]
+        log10_cooling_rate: True
         file_format: "lammps-data"
         cutoff: 10.0
         species: [8, 14]
@@ -139,7 +202,7 @@ Sample:
   metrics:
     __class_name__: DM2AmorphousGenerationMetric
     __init_params__:
-      reference_paths: "./data/dm2/sio2/reference/*.dat"
+      reference_paths: "./data/dm2/sio2/conditional/reference/*.dat"
       file_format: "lammps-data"
       rdf_cutoff: 8.0
       rdf_bins: 200

--- a/structure_generation/configs/dm2/dm2_sio2_unconditional.yaml
+++ b/structure_generation/configs/dm2/dm2_sio2_unconditional.yaml
@@ -1,3 +1,10 @@
+# DM2 a-SiO2 unconditional reproduction config.
+#
+# Expected data layout follows the official DM2 demo files:
+#   data/dm2/sio2/unconditional/train/sio2_3000_glass_1k_sample{0,1,2}.dat
+#   data/dm2/sio2/unconditional/sample/random_sio2_size_300_demo.dat
+#   data/dm2/sio2/unconditional/reference/*.dat
+
 Global:
   do_train: True
   do_eval: False
@@ -6,7 +13,7 @@ Global:
 Trainer:
   max_epochs: 200
   seed: 42
-  output_dir: ./output/dm2_sio2
+  output_dir: ./output/dm2_sio2_unconditional
   save_freq: 20
   log_freq: 10
   start_eval_epoch: 1
@@ -72,7 +79,10 @@ Dataset:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/train/*.dat"
+        paths:
+          - "./data/dm2/sio2/unconditional/train/sio2_3000_glass_1k_sample0.dat"
+          - "./data/dm2/sio2/unconditional/train/sio2_3000_glass_1k_sample1.dat"
+          - "./data/dm2/sio2/unconditional/train/sio2_3000_glass_1k_sample2.dat"
         file_format: "lammps-data"
         cutoff: 10.0
         species: [8, 14]
@@ -91,7 +101,7 @@ Dataset:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/val/*.dat"
+        paths: "./data/dm2/sio2/unconditional/val/*.dat"
         file_format: "lammps-data"
         cutoff: 10.0
         species: [8, 14]
@@ -116,7 +126,7 @@ Sample:
     dataset:
       __class_name__: DM2StructureDataset
       __init_params__:
-        paths: "./data/dm2/sio2/sample/*.dat"
+        paths: "./data/dm2/sio2/unconditional/sample/*.dat"
         file_format: "lammps-data"
         cutoff: 10.0
         species: [8, 14]
@@ -139,7 +149,7 @@ Sample:
   metrics:
     __class_name__: DM2AmorphousGenerationMetric
     __init_params__:
-      reference_paths: "./data/dm2/sio2/reference/*.dat"
+      reference_paths: "./data/dm2/sio2/unconditional/reference/*.dat"
       file_format: "lammps-data"
       rdf_cutoff: 8.0
       rdf_bins: 200

--- a/structure_generation/sample.py
+++ b/structure_generation/sample.py
@@ -130,7 +130,7 @@ class StructureSampler:
 
     def sample(self, data, sample_params=None):
         if sample_params is None:
-            sample_params = {}
+            sample_params = self.sample_config.get("sample_params", {})
         assert isinstance(sample_params, dict), "sample_params must be a dict or None."
         pred_data = self.model.sample(data, **sample_params)
         pred_data = self.post_process(pred_data)
@@ -139,7 +139,12 @@ class StructureSampler:
     def sample_by_dataloader(
         self,
         save_path=None,
+        sample_params=None,
     ):
+        if sample_params is None:
+            sample_params = self.sample_config.get("sample_params", {})
+        assert isinstance(sample_params, dict), "sample_params must be a dict or None."
+
         dataset_cfg = self.sample_config["data"]
         data_loader = build_dataloader(dataset_cfg)
 
@@ -151,7 +156,7 @@ class StructureSampler:
 
         total_results = []
         for iter_id, batch_data in enumerate(data_loader):
-            pred_data = self.model.sample(batch_data)
+            pred_data = self.model.sample(batch_data, **sample_params)
             structures = structure_converter(pred_data["result"])
             if save_path is not None:
                 os.makedirs(save_path, exist_ok=True)

--- a/test/test_dm2_model.py
+++ b/test/test_dm2_model.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import paddle
+
+from ppmat.datasets.geometric_data_type.batch import Batch
+from ppmat.datasets.geometric_data_type.data import Data
+from ppmat.models.dm2 import DM2
+
+
+def _toy_graph(offset=0.0):
+    pos = paddle.to_tensor(
+        [
+            [0.0 + offset, 0.0, 0.0],
+            [0.8 + offset, 0.0, 0.0],
+            [0.0 + offset, 0.8, 0.0],
+        ],
+        dtype="float32",
+    )
+    edge_index = paddle.to_tensor(
+        [
+            [0, 1, 2, 1, 2, 0],
+            [1, 2, 0, 0, 1, 2],
+        ],
+        dtype="int64",
+    )
+    src, dst = edge_index[0], edge_index[1]
+    return Data(
+        x=paddle.to_tensor([0, 1, 0], dtype="int64"),
+        pos=pos,
+        edge_index=edge_index,
+        edge_attr=pos[dst] - pos[src],
+        atomic_numbers=paddle.to_tensor([8, 14, 8], dtype="int64"),
+        lattice=paddle.eye(3, dtype="float32").unsqueeze(axis=0) * 5.0,
+        cooling_rate=paddle.to_tensor([1.0], dtype="float32"),
+        num_nodes=3,
+    )
+
+
+def test_dm2_forward_and_sample_smoke():
+    paddle.seed(42)
+    model = DM2(
+        cutoff=2.0,
+        sigma_min=0.001,
+        sigma_max=0.01,
+        denoiser_cfg={
+            "num_species": 2,
+            "node_embedding_dim": 4,
+            "edge_basis_size": 4,
+            "irreps_hidden": "8x0e + 4x1e",
+            "irreps_edge": "2x0e + 1x1e",
+            "irreps_out": "1x1e",
+            "num_convs": 2,
+            "radial_neurons": [4, 8],
+            "num_neighbors": 3,
+            "use_condition": True,
+        },
+    )
+    batch = Batch.from_data_list([_toy_graph(), _toy_graph(offset=1.0)])
+    result = model(batch)
+    assert "loss" in result["loss_dict"]
+    assert np.isfinite(float(result["loss_dict"]["loss"]))
+
+    sampled = model.sample(batch, num_inference_steps=2, final_relax_steps=1)
+    assert len(sampled["result"]) == 2
+    assert sampled["result"][0]["frac_coords"].shape == (3, 3)

--- a/test/test_dm2_model.py
+++ b/test/test_dm2_model.py
@@ -14,7 +14,9 @@
 
 import numpy as np
 import paddle
+import pytest
 
+from ppmat.schedulers.scheduling_dm2 import DM2DenoisingScheduler
 from ppmat.datasets.geometric_data_type.batch import Batch
 from ppmat.datasets.geometric_data_type.data import Data
 from ppmat.models.dm2 import DM2
@@ -67,12 +69,80 @@ def test_dm2_forward_and_sample_smoke():
             "num_neighbors": 3,
             "use_condition": True,
         },
+        scheduler_cfg={
+            "sigma_min": 0.001,
+            "sigma_max": 0.01,
+            "default_num_inference_steps": 2,
+            "default_final_relax_steps": 1,
+        },
     )
     batch = Batch.from_data_list([_toy_graph(), _toy_graph(offset=1.0)])
     result = model(batch)
     assert "loss" in result["loss_dict"]
     assert np.isfinite(float(result["loss_dict"]["loss"]))
 
-    sampled = model.sample(batch, num_inference_steps=2, final_relax_steps=1)
+    sampled = model.sample(batch)
     assert len(sampled["result"]) == 2
     assert sampled["result"][0]["frac_coords"].shape == (3, 3)
+
+
+def test_dm2_scheduler_fixed_sigma():
+    graph = _toy_graph()
+    scheduler = DM2DenoisingScheduler(sigma_min=0.1, sigma_max=0.1)
+    noisy_graph = scheduler.add_noise(graph, sigma=0.1)
+    assert noisy_graph.dx.shape == noisy_graph.pos.shape
+    assert noisy_graph.sigma.shape == [3, 1]
+    assert paddle.allclose(
+        noisy_graph.pos,
+        _toy_graph().pos + noisy_graph.dx,
+        atol=1e-6,
+    )
+
+
+def test_dm2_metric_smoke(tmp_path):
+    pytest.importorskip("ase")
+    pytest.importorskip("pandas")
+    pytest.importorskip("p_tqdm")
+    pytest.importorskip("pymatgen")
+    pytest.importorskip("smact")
+    pytest.importorskip("matminer")
+    pytest.importorskip("scipy")
+
+    from ase import Atoms
+    import ase.io
+    from ppmat.metrics.dm2_metric import DM2AmorphousGenerationMetric
+
+    atoms = Atoms(
+        numbers=[14, 8, 8],
+        scaled_positions=[[0.0, 0.0, 0.0], [0.25, 0.0, 0.0], [0.0, 0.25, 0.0]],
+        cell=np.eye(3) * 6.0,
+        pbc=True,
+    )
+    ref_path = tmp_path / "ref.extxyz"
+    ase.io.write(ref_path, atoms, format="extxyz")
+
+    metric = DM2AmorphousGenerationMetric(
+        reference_paths=str(ref_path),
+        file_format="extxyz",
+        rdf_cutoff=4.0,
+        rdf_bins=16,
+        coordination_cutoffs=[
+            {
+                "name": "si_o_coordination",
+                "center_atomic_number": 14,
+                "neighbor_atomic_number": 8,
+                "cutoff": 2.0,
+            }
+        ],
+    )
+    result = metric(
+        [
+            {
+                "frac_coords": atoms.get_scaled_positions(),
+                "atom_types": atoms.numbers,
+                "lattice": atoms.cell.array,
+            }
+        ]
+    )
+    assert result["rdf_wasserstein"] == 0.0
+    assert result["si_o_coordination"] == 2.0


### PR DESCRIPTION
## What changed

- Add a Paddle implementation of the DM2 structure denoising model, including the NequIP-style denoiser, noise/rattle utilities, edge down-selection, training forward pass, and iterative sampling path.
- Add an ASE-backed `DM2StructureDataset` and DM2 SiO2 example configuration under `structure_generation/configs/dm2`.
- Register DM2 model and dataset exports, document the new structure generation entry, and add a focused DM2 smoke test.
- Fix `Irreps` sorting in the local e3nn `Gate` helper so DM2's gate construction works at runtime.

## Related

- Hackathon task: PaddlePaddle/Paddle#77429
- PPMat model list: PaddlePaddle/PaddleMaterials#194
- RFC / design doc: PaddlePaddle/community#1344

## Validation

- `python3 -m py_compile ppmat/models/common/e3nn/nn/_gate.py ppmat/models/dm2/dm2.py ppmat/datasets/dm2_dataset.py test/test_dm2_model.py`
- Parsed `structure_generation/configs/dm2/dm2_sio2.yaml` with PyYAML
- Ran a targeted DM2 runtime smoke test covering model construction, finite forward loss, and iterative sampling output shapes
- `git diff --cached --check`