### PR TITLE
[codex] add homepage badge and single-line inference command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 </p>
 
 <p align="center">
+  <a href="https://paddlepaddle.github.io/PaddleMaterials/">
+    <img alt="Homepage" src="https://img.shields.io/badge/Homepage-PaddleMaterials-3B82F6?style=flat">
+  </a>
   <a href="Install.md">
     <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&amp;logoColor=white">
   </a>

--- a/docs/script.js
+++ b/docs/script.js
@@ -27,16 +27,8 @@ const quickstartCommands = {
   },
   predict: {
     file: 'property_prediction / predict.py',
-    command: String.raw`python property_prediction/predict.py \
-    --model_name='megnet_mp2018_train_60k_e_form' \
-    --weights_name='best.pdparams' \
-    --cif_file_path='./property_prediction/example_data/cifs/' \
-    --save_path='result.csv'`,
-    html: String.raw`<span class="token-purple">python</span> property_prediction/predict.py \
-    --model_name='megnet_mp2018_train_60k_e_form' \
-    --weights_name='best.pdparams' \
-    --cif_file_path='./property_prediction/example_data/cifs/' \
-    --save_path='result.csv'`,
+    command: "python property_prediction/predict.py --model_name='megnet_mp2018_train_60k_e_form' --weights_name='best.pdparams' --cif_file_path='./property_prediction/example_data/cifs/' --save_path='result.csv'",
+    html: String.raw`<span class="token-purple">python</span> property_prediction/predict.py <span class="token-blue">--model_name='megnet_mp2018_train_60k_e_form'</span> <span class="token-blue">--weights_name='best.pdparams'</span> <span class="token-blue">--cif_file_path='./property_prediction/example_data/cifs/'</span> <span class="token-blue">--save_path='result.csv'</span>`,
     status: 'prediction output <span class="mono">·</span> CSV',
   },
 };

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -5,6 +5,7 @@ const test = require('node:test');
 
 const homepageDir = path.join(__dirname, '..', 'docs');
 const html = readFileSync(path.join(homepageDir, 'index.html'), 'utf8');
+const readme = readFileSync(path.join(__dirname, '..', 'README.md'), 'utf8');
 const script = readFileSync(path.join(homepageDir, 'script.js'), 'utf8');
 
 const trainCommand = 'python property_prediction/train.py -c property_prediction/configs/megnet/megnet_mp2018_train_60k_e_form.yaml';
@@ -74,12 +75,20 @@ test('all documented task datasets are represented on capability cards', () => {
 
 test('quickstart uses complete README training and inference commands', () => {
   assert.ok(html.includes(trainCommand), 'initial training command is incomplete');
-  assert.ok(script.includes(trainCommand), 'training tab command is incomplete');
-  for (const fragment of predictFragments) {
+  const inferenceCommand = "python property_prediction/predict.py --model_name='megnet_mp2018_train_60k_e_form' --weights_name='best.pdparams' --cif_file_path='./property_prediction/example_data/cifs/' --save_path='result.csv'";
+  assert.ok(script.includes(inferenceCommand), 'inference command should be represented as one copyable line');
+  for (const fragment of [
+    'property_prediction/predict.py',
+    "--model_name='megnet_mp2018_train_60k_e_form'",
+    "--weights_name='best.pdparams'",
+    "--cif_file_path='./property_prediction/example_data/cifs/'",
+    "--save_path='result.csv'",
+  ]) {
     assert.ok(script.includes(fragment), `missing inference command fragment: ${fragment}`);
   }
   assert.doesNotMatch(script, /command\.slice\(6\)/, 'command rendering must not rely on slicing a multiline command');
-  assert.match(script, /html: String\.raw`<span class=\"token-purple\">python<\/span> property_prediction\/predict\.py/, 'inference display must preserve README line continuations');
+  assert.doesNotMatch(script, /property_prediction\/predict\.py\s*\\\s*\n/, 'inference display should not split the command with line continuations');
+  assert.match(script, /html: String\.raw`<span class=\"token-purple\">python<\/span> property_prediction\/predict\.py/, 'inference display should keep syntax highlighting');
 });
 
 
@@ -93,4 +102,12 @@ test('GitHub Pages homepage is published from docs without a separate assets dir
   assert.match(publishedHtml, /src="\.\/materials-discovery-loop\.png"/);
   assert.doesNotMatch(publishedHtml, /(?:src|href)="\.\/assets\//);
   assert.equal(existsSync(path.join(__dirname, '..', 'homepage', 'assets')), false, 'homepage/assets should be removed');
+});
+
+
+test('README links to the published homepage badge', () => {
+  assert.match(
+    readme,
+    /<a href="https:\/\/paddlepaddle\.github\.io\/PaddleMaterials\/">\s*<img alt="Homepage" src="https:\/\/img\.shields\.io\/badge\/Homepage-PaddleMaterials-[^"]+">\s*<\/a>/,
+  );
 });


### PR DESCRIPTION
## Summary
- Render the homepage inference command as a single line, matching the training command presentation.
- Keep the displayed command and copied command identical and complete.
- Add a clickable Homepage badge to the root README linking to the published GitHub Pages site.
- Extend homepage regression coverage for the one-line inference command and README badge.

## Context
PR #311 was merged before these follow-up changes were pushed to its source branch. This PR contains only the remaining command presentation and README badge updates relative to the latest `develop` branch.

## Validation
- `node --test tests/homepage.test.js`
- `node --check docs/script.js`
- `git diff --check origin/develop...HEAD`
- Local browser verification: inference display and copy value are the same single-line command; all images load and no horizontal overflow is introduced
